### PR TITLE
Load filters in crawler base class

### DIFF
--- a/lib/daimon_skycrawlers/crawler/base.rb
+++ b/lib/daimon_skycrawlers/crawler/base.rb
@@ -5,6 +5,8 @@ require "daimon_skycrawlers/logger"
 require "daimon_skycrawlers/config"
 require "daimon_skycrawlers/storage"
 require "daimon_skycrawlers/processor"
+require "daimon_skycrawlers/filter/update_checker"
+require "daimon_skycrawlers/filter/robots_txt_checker"
 
 module DaimonSkycrawlers
   module Crawler

--- a/lib/daimon_skycrawlers/crawler/default.rb
+++ b/lib/daimon_skycrawlers/crawler/default.rb
@@ -1,6 +1,4 @@
 require "daimon_skycrawlers/crawler/base"
-require "daimon_skycrawlers/filter/update_checker"
-require "daimon_skycrawlers/filter/robots_txt_checker"
 
 module DaimonSkycrawlers
   module Crawler


### PR DESCRIPTION
I made UpdateChecker and RobotTxtChecker be loaded in crawler base class. Because I run my own crawler inheriting from `DaimonSkyCrawlers::Crawler::Base`, I got an error below:

```
E, [2016-10-24T18:24:26.574471 #10499] ERROR -- : uninitialized constant DaimonSkycrawlers::Filter (NameError)
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/daimon_skycrawlers-0.6.0/lib/daimon_skycrawlers/crawler/base.rb:118:in `apply_filters'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/daimon_skycrawlers-0.6.0/lib/daimon_skycrawlers/crawler/base.rb:88:in `process'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/daimon_skycrawlers-0.6.0/lib/daimon_skycrawlers/consumer/url.rb:51:in `block in process'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/daimon_skycrawlers-0.6.0/lib/daimon_skycrawlers/consumer/url.rb:50:in `each'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/daimon_skycrawlers-0.6.0/lib/daimon_skycrawlers/consumer/url.rb:50:in `process'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/songkick_queue-1.0.0/lib/songkick_queue/worker.rb:102:in `block in process_message'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.1/lib/active_support/notifications.rb:164:in `block in instrument'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.1/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.1/lib/active_support/notifications.rb:164:in `instrument'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/songkick_queue-1.0.0/lib/songkick_queue/worker.rb:101:in `process_message'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/songkick_queue-1.0.0/lib/songkick_queue/worker.rb:71:in `block in subscribe_to_queue'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer.rb:56:in `call'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/channel.rb:1705:in `block in handle_frameset'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer_work_pool.rb:107:in `block (2 levels) in run_loop'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer_work_pool.rb:102:in `loop'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer_work_pool.rb:102:in `block in run_loop'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer_work_pool.rb:101:in `catch'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer_work_pool.rb:101:in `run_loop'
```