### PR TITLE
Update bundler for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.2.5
   - 2.3.1
 
-before_install: gem install bundler -v 1.11.2
+before_install: gem update bundler
 
 services:
   - rabbitmq


### PR DESCRIPTION
I think there are no reason to use old bundler.