### PR TITLE
Create filter file and directory when new command is invoked

### DIFF
--- a/lib/daimon_skycrawlers/generator/new.rb
+++ b/lib/daimon_skycrawlers/generator/new.rb
@@ -71,6 +71,7 @@ module DaimonSkycrawlers
           "Gemfile",
           "Rakefile",
           "app/crawlers/sample_crawler.rb",
+          "app/filters/sample_filter.rb",
           "app/processors/sample_processor.rb",
           "config/init.rb",
           "services/common/docker-entrypoint.sh",

--- a/lib/daimon_skycrawlers/generator/templates/new/app/filters/sample_filter.rb
+++ b/lib/daimon_skycrawlers/generator/templates/new/app/filters/sample_filter.rb
@@ -1,0 +1,7 @@
+require "daimon_skycrawlers/filter/base"
+
+class SampleFilter < DaimonSkycrawlers::Filter::Base
+  def call(url)
+    # Imprement your filter here.
+  end
+end


### PR DESCRIPTION
Generate `app/filters/` directory and `sample_filter.rb` when `daimon_skycrawlers new APPNAME` command is invoked.
Users may usually need filters to assign works to appropriate crawlers or processors.