### PR TITLE
Pass the copy of message hash to be used among all crawlers

### DIFF
--- a/lib/daimon_skycrawlers/consumer/url.rb
+++ b/lib/daimon_skycrawlers/consumer/url.rb
@@ -48,7 +48,7 @@ module DaimonSkycrawlers
 
         # XXX When several crawlers are registered, how should they behave?
         self.class.crawlers.each do |crawler|
-          crawler.process(message)
+          crawler.process(message.dup)
           if crawler.skipped?
             sleep(crawler_interval) if crawler.n_processed_urls % 50 == 0
           else


### PR DESCRIPTION
The `message` hash is used among all registered crawlers.
However the original hash is modified by `Hash#delete` here.
 https://github.com/bm-sms/daimon_skycrawlers/blob/master/lib/daimon_skycrawlers/crawler/base.rb#L100
 
If user registers multiple crawlers, `cralwer.process(message)` from second crawler is executed with `message` hash without `url` key and its value, then `URI#+`(identical to `URI#merge`) fails with `nil` object. Users will get error like this:

```
E, [2016-12-08T12:35:03.998688 #1388] ERROR -- : bad argument (expected URI object or URI string) (ArgumentError)
/usr/local/rbenv/versions/2.3.1/lib/ruby/2.3.0/uri/generic.rb:1102:in `rescue in merge'
/usr/local/rbenv/versions/2.3.1/lib/ruby/2.3.0/uri/generic.rb:1099:in `merge'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/daimon_skycrawlers-0.11.1/lib/daimon_skycrawlers/crawler/base.rb:99:in `process'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/daimon_skycrawlers-0.11.1/lib/daimon_skycrawlers/consumer/url.rb:51:in `block in process'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/daimon_skycrawlers-0.11.1/lib/daimon_skycrawlers/consumer/url.rb:50:in `each'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/daimon_skycrawlers-0.11.1/lib/daimon_skycrawlers/consumer/url.rb:50:in `process'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/songkick_queue-1.0.0/lib/songkick_queue/worker.rb:102:in `block in process_message'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.1/lib/active_support/notifications.rb:164:in `block in instrument'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.1/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.1/lib/active_support/notifications.rb:164:in `instrument'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/songkick_queue-1.0.0/lib/songkick_queue/worker.rb:101:in `process_message'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/songkick_queue-1.0.0/lib/songkick_queue/worker.rb:71:in `block in subscribe_to_queue'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer.rb:56:in `call'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/channel.rb:1705:in `block in handle_frameset'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer_work_pool.rb:107:in `block (2 levels) in run_loop'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer_work_pool.rb:102:in `loop'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer_work_pool.rb:102:in `block in run_loop'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer_work_pool.rb:101:in `catch'
/usr/local/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bunny-2.6.1/lib/bunny/consumer_work_pool.rb:101:in `run_loop'
```

This will be solved to pass the copy of the original `message` object.