### PR TITLE
Add RubyGems badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # DaimonSkycrawlers
 
+[![Gem Version](https://badge.fury.io/rb/daimon_skycrawlers.svg)](https://badge.fury.io/rb/daimon_skycrawlers)
+
 DaimonSkycrawlers is a crawler framework.
 
 ## Requirements


### PR DESCRIPTION
Since it is published to RubyGems.org, we can recognize the gems version by looking at README.md.