### PR TITLE
Fix log message (print which crawler/processor to skip)

### DIFF
--- a/lib/daimon_skycrawlers/crawler/base.rb
+++ b/lib/daimon_skycrawlers/crawler/base.rb
@@ -142,7 +142,7 @@ module DaimonSkycrawlers
       end
 
       def skip(url)
-        log.info("Skip #{url}")
+        log.info("Skipped '#{url}' by '#{self.class}'")
         @skipped = true
         schedule_to_process(url.to_s, heartbeat: true)
       end

--- a/lib/daimon_skycrawlers/processor/base.rb
+++ b/lib/daimon_skycrawlers/processor/base.rb
@@ -41,7 +41,7 @@ module DaimonSkycrawlers
       private
 
       def skip(url)
-        log.info("Skip #{url}")
+        log.info("Skipped '#{url}' by '#{self.class}'")
         @skipped = true
       end
     end


### PR DESCRIPTION
Print which crawler/processor to skip the message to log messages.
This will make users understand each `before_process` condition works as expected.
