### PR TITLE
Fix callback method names

### DIFF
--- a/lib/daimon_skycrawlers/callbacks.rb
+++ b/lib/daimon_skycrawlers/callbacks.rb
@@ -52,7 +52,7 @@ module DaimonSkycrawlers
       end
     end
 
-    def run_after_callbacks(message)
+    def run_after_process_callbacks(message)
       @after_process_callbacks.each do |callback|
         callback.call(message)
       end

--- a/lib/daimon_skycrawlers/callbacks.rb
+++ b/lib/daimon_skycrawlers/callbacks.rb
@@ -24,7 +24,7 @@ module DaimonSkycrawlers
       end
     end
 
-    def run_before_callbacks(message)
+    def run_before_process_callbacks(message)
       @before_process_callbacks.all? do |callback|
         callback.call(message)
       end

--- a/lib/daimon_skycrawlers/crawler/base.rb
+++ b/lib/daimon_skycrawlers/crawler/base.rb
@@ -128,7 +128,7 @@ module DaimonSkycrawlers
         @prepare.call(connection)
         response = fetch(url, message, &block)
         data = { url: url, message: message, response: response }
-        run_after_callbacks(data)
+        run_after_process_callbacks(data)
         data
       end
 

--- a/lib/daimon_skycrawlers/crawler/base.rb
+++ b/lib/daimon_skycrawlers/crawler/base.rb
@@ -115,7 +115,7 @@ module DaimonSkycrawlers
         @skipped = false
         @n_processed_urls += 1
 
-        proceeding = run_before_callbacks(message)
+        proceeding = run_before_process_callbacks(message)
         unless proceeding
           skip(message[:url])
           return

--- a/lib/daimon_skycrawlers/processor/base.rb
+++ b/lib/daimon_skycrawlers/processor/base.rb
@@ -38,7 +38,7 @@ module DaimonSkycrawlers
       #
       def process(message)
         @skipped = false
-        proceeding = run_before_callbacks(message)
+        proceeding = run_before_process_callbacks(message)
         unless proceeding
           skip(message[:url])
           return

--- a/test/daimon_skycrawlers/test_callbacks.rb
+++ b/test/daimon_skycrawlers/test_callbacks.rb
@@ -13,7 +13,7 @@ class DaimonSkycrawlersCallbacksTest < Test::Unit::TestCase
     end
 
     def process(message)
-      proceeding = run_before_callbacks(message)
+      proceeding = run_before_process_callbacks(message)
       return unless proceeding
       @processed = true
       data = {

--- a/test/daimon_skycrawlers/test_callbacks.rb
+++ b/test/daimon_skycrawlers/test_callbacks.rb
@@ -21,7 +21,7 @@ class DaimonSkycrawlersCallbacksTest < Test::Unit::TestCase
         message: message,
         response: ""
       }
-      run_after_callbacks(data)
+      run_after_process_callbacks(data)
     end
   end
 


### PR DESCRIPTION
Use unified method name. I've got confused with the name with or without `_process`.