### PR TITLE
Change to use extract_link in retrieve_links

### DIFF
--- a/lib/daimon_skycrawlers/processor/spider.rb
+++ b/lib/daimon_skycrawlers/processor/spider.rb
@@ -128,7 +128,7 @@ module DaimonSkycrawlers
 
       def retrieve_links
         urls = @doc.search(*link_rules).map do |element|
-          @extract_next_page_link.call(element)
+          @extract_link.call(element)
         end
         urls.uniq!
         apply_link_filters(urls) || []


### PR DESCRIPTION
I think `extract_next_page_link` should be used only for `next_page_link`.
And, there is no meaning to define because `extract_link` is not currently used... :/