### PR TITLE
Add Enumerable check

### DIFF
--- a/lib/daimon_skycrawlers/processor/spider.rb
+++ b/lib/daimon_skycrawlers/processor/spider.rb
@@ -138,6 +138,10 @@ module DaimonSkycrawlers
         return unless next_page_link_rules
         element = @doc.at(*next_page_link_rules)
         return unless element
+        if element.is_a?(Enumerable)
+          log.info("element: #{element}. element is Enumerable. next_page_link must be just one.")
+          return
+        end
         @extract_next_page_link.call(element)
       end
 


### PR DESCRIPTION
I guess `next_page_link` is just one. so, expect fetched element by next_page_link_rules is not Enumerable.