### PR TITLE
Organize storage API to read data

### DIFF
--- a/lib/daimon_skycrawlers/filter/update_checker.rb
+++ b/lib/daimon_skycrawlers/filter/update_checker.rb
@@ -23,7 +23,8 @@ module DaimonSkycrawlers
       #
       def call(message, connection: nil)
         url = normalize_url(message[:url])
-        page = storage.read(url, message)
+        message[:url] = url
+        page = storage.read(message)
         return true unless page
         if connection
           response = connection.head(url)

--- a/lib/daimon_skycrawlers/processor/default.rb
+++ b/lib/daimon_skycrawlers/processor/default.rb
@@ -11,8 +11,7 @@ module DaimonSkycrawlers
       # Display page information
       #
       def call(message)
-        url = message[:url]
-        page = storage.read(url, message)
+        page = storage.read(message)
         headers = JSON.parse(page.headers)
         headers_string = headers.map {|key, value| "  #{key}: #{value}" }.join("\n")
         dumped_message = <<LOG

--- a/lib/daimon_skycrawlers/processor/spider.rb
+++ b/lib/daimon_skycrawlers/processor/spider.rb
@@ -99,10 +99,9 @@ module DaimonSkycrawlers
       # @param message [Hash] Must have key :url, :depth
       #
       def call(message)
-        key_url = message[:url]
         depth = Integer(message[:depth] || 2)
         return if depth <= 1
-        page = storage.read(key_url, message)
+        page = storage.read(message)
         unless page
           log.warn("Could not read page: url=#{message[:url]}, key=#{message[:key]}")
           return

--- a/lib/daimon_skycrawlers/storage/base.rb
+++ b/lib/daimon_skycrawlers/storage/base.rb
@@ -29,9 +29,9 @@ module DaimonSkycrawlers
       #
       # Override this method in subclass
       #
-      # @param url [String] the key to find data in storage
+      # @param message [Hash] this hash can include `:url`, `:key` to find page
       #
-      def read(url, message = {})
+      def read(message = {})
         raise "Implement this in subclass"
       end
     end

--- a/lib/daimon_skycrawlers/storage/file.rb
+++ b/lib/daimon_skycrawlers/storage/file.rb
@@ -39,9 +39,11 @@ module DaimonSkycrawlers
       #
       # Read data from files under base directory
       #
+      # @param message [Hash] this hash can include `:url`, `:key` to find page
       # @return [DaimonSkycrawlers::Storage::File::Page]
       #
-      def read(url, message)
+      def read(message)
+        url = message[:url]
         key = message[:key]
         headers = JSON.parse(headers_path(url, key).read)
         body = body_path(url, key).read

--- a/lib/daimon_skycrawlers/storage/null.rb
+++ b/lib/daimon_skycrawlers/storage/null.rb
@@ -16,7 +16,7 @@ module DaimonSkycrawlers
       #
       # Read nothing
       #
-      def read(url, message = {})
+      def read(message = {})
       end
     end
   end

--- a/lib/daimon_skycrawlers/storage/rdb.rb
+++ b/lib/daimon_skycrawlers/storage/rdb.rb
@@ -39,10 +39,10 @@ module DaimonSkycrawlers
       #
       # Fetch page identified by url
       #
-      # @param url [String] identity of the page
-      # @param message [Hash] this hash may include `:key` to find page
+      # @param message [Hash] this hash can include `:url`, `:key` to find page
       #
-      def read(url, message = {})
+      def read(message = {})
+        url = message[:url]
         key = message[:key]
         if key
           Page.where(key: key).order(updated_at: :desc).limit(1).first

--- a/sample/amazon-ranking/app/processors/amazon_ranking.rb
+++ b/sample/amazon-ranking/app/processors/amazon_ranking.rb
@@ -6,8 +6,7 @@ require "daimon_skycrawlers/processor/spider"
 class AmazonRanking < DaimonSkycrawlers::Processor::Base
   Item = Struct.new(:rank, :name, :url, :star, :review)
   def call(message)
-    url = message[:url]
-    page = storage.read(url)
+    page = storage.read(message)
     doc = Nokogiri::HTML(page.body)
     ranking = []
     doc.search(".zg_itemRow").each do |item|

--- a/sample/itp-crawler/app/processors/itp_processor.rb
+++ b/sample/itp-crawler/app/processors/itp_processor.rb
@@ -7,7 +7,7 @@ require_relative "../models/itp_shop"
 class ItpProcessor < DaimonSkycrawlers::Processor::Base
   def call(message)
     key_url = message[:url]
-    page = storage.read(key_url)
+    page = storage.read(message)
     @doc = Nokogiri::HTML(page.body.encode("UTF-8", "CP932"))
     ItpShop.transaction do
       prepare_shops do |shop|

--- a/test/daimon_skycrawlers/filter/test_update_checker.rb
+++ b/test/daimon_skycrawlers/filter/test_update_checker.rb
@@ -11,7 +11,7 @@ class DaimonSkycrawlersUpdateCheckerTest < Test::Unit::TestCase
   end
 
   test "url does not exist in storage" do
-    mock(@storage).read(@url, url: @url) { nil }
+    mock(@storage).read(url: @url) { nil }
     assert_true(@filter.call({ url: @url }))
   end
 
@@ -19,7 +19,7 @@ class DaimonSkycrawlersUpdateCheckerTest < Test::Unit::TestCase
     test "need update when no etag and no last-modified" do
       page = DaimonSkycrawlers::Storage::RDB::Page.new(url: @url)
       connection = create_stub_connection(@url)
-      mock(@storage).read(@url, url: @url) { page }
+      mock(@storage).read(url: @url) { page }
       assert_true(@filter.call({ url: @url }, connection: connection))
     end
 
@@ -27,7 +27,7 @@ class DaimonSkycrawlersUpdateCheckerTest < Test::Unit::TestCase
       now = Time.now
       page = DaimonSkycrawlers::Storage::RDB::Page.new(url: @url, last_modified_at: Time.at(now - 1))
       connection = create_stub_connection(@url, "last-modified" => now)
-      mock(@storage).read(@url, url: @url) { page }
+      mock(@storage).read(url: @url) { page }
       assert_true(@filter.call({ url: @url }, connection: connection))
     end
 
@@ -35,14 +35,14 @@ class DaimonSkycrawlersUpdateCheckerTest < Test::Unit::TestCase
       now = Time.now
       page = DaimonSkycrawlers::Storage::RDB::Page.new(url: @url, last_modified_at: Time.at(now - 1))
       connection = create_stub_connection(@url, "last-modified" => Time.at(now - 2))
-      mock(@storage).read(@url, url: @url) { page }
+      mock(@storage).read(url: @url) { page }
       assert_false(@filter.call({ url: @url }, connection: connection))
     end
 
     test "etag matches" do
       page = DaimonSkycrawlers::Storage::RDB::Page.new(url: @url, etag: "xxxxx")
       connection = create_stub_connection(@url, "etag" => "xxxxx")
-      mock(@storage).read(@url, url: @url) { page }
+      mock(@storage).read(url: @url) { page }
       assert_false(@filter.call({ url: @url }, connection: connection))
     end
 
@@ -50,14 +50,14 @@ class DaimonSkycrawlersUpdateCheckerTest < Test::Unit::TestCase
       now = Time.now
       page = DaimonSkycrawlers::Storage::RDB::Page.new(url: @url, etag: "xxxxx", last_modified_at: now)
       connection = create_stub_connection(@url, "etag" => "yyyyy", "last-modified" => Time.at(now + 1))
-      mock(@storage).read(@url, url: @url) { page }
+      mock(@storage).read(url: @url) { page }
       assert_true(@filter.call({ url: @url }, connection: connection))
     end
 
     test "need update with relative path w/o headers" do
       page = DaimonSkycrawlers::Storage::RDB::Page.new(url: @url)
       connection = create_stub_connection("/blog/2016/1.html")
-      mock(@storage).read(@url, url: "./2016/1.html") { page }
+      mock(@storage).read(url: "http://example.com/blog/2016/1.html") { page }
       assert_true(@filter.call({ url: "./2016/1.html" }, connection: connection))
     end
 

--- a/test/daimon_skycrawlers/processor/test_spider.rb
+++ b/test/daimon_skycrawlers/processor/test_spider.rb
@@ -22,7 +22,7 @@ class DaimonSkycrawlersSpiderTest < Test::Unit::TestCase
       end
     end
     page = OpenStruct.new(headers: {}, body: "")
-    mock(@storage).read(url, { url: url }).returns { page }
+    mock(@storage).read(url: url).returns { page }
     @spider.process(url: url)
   end
 
@@ -31,7 +31,7 @@ class DaimonSkycrawlersSpiderTest < Test::Unit::TestCase
       @spider.enqueue = false
       @url = "http://www.clear-code.com/blog.html"
       page = OpenStruct.new(headers: {}, body: fixture_path("www.clear-code.com/blog.html").read)
-      mock(@storage).read(@url, { url: @url}).returns { page }
+      mock(@storage).read(url: @url).returns { page }
     end
 
     test "enqueue all links" do
@@ -95,7 +95,7 @@ class DaimonSkycrawlersSpiderTest < Test::Unit::TestCase
       @spider.enqueue = false
       @url = "http://www.clear-code.com/search-result.html"
       page = OpenStruct.new(headers: {}, body: fixture_path("www.clear-code.com/search-result.html").read)
-      mock(@storage).read(@url, { url: @url}).returns { page }
+      mock(@storage).read(url: @url).returns { page }
     end
 
     test "search result and next page" do
@@ -125,7 +125,7 @@ class DaimonSkycrawlersSpiderTest < Test::Unit::TestCase
       @spider.enqueue = false
       @url = "http://www.clear-code.com/search-result.html"
       page = OpenStruct.new(headers: {}, body: fixture_path("www.clear-code.com/search-result-last-page.html").read)
-      mock(@storage).read(@url, { url: @url}).returns { page }
+      mock(@storage).read(url: @url).returns { page }
     end
 
     test "search result w/o next page" do

--- a/test/daimon_skycrawlers/storage/test_file.rb
+++ b/test/daimon_skycrawlers/storage/test_file.rb
@@ -22,7 +22,7 @@ class DaimonSkycrawlers::Storage::FileTest < Test::Unit::TestCase
     @storage.save(data)
     assert { File.exist?(@base_dir + "/blog/index.html") }
     assert { File.exist?(@base_dir + "/blog/index.html-headers.json") }
-    page = @storage.read(url, {})
+    page = @storage.read(url: url)
     expected = {
       url: url,
       key: nil,

--- a/test/daimon_skycrawlers/storage/test_rdb.rb
+++ b/test/daimon_skycrawlers/storage/test_rdb.rb
@@ -23,7 +23,7 @@ class DaimonSkycrawlers::Storage::RDBTest < Test::Unit::TestCase
     assert_nothing_raised do
       @storage.save(data)
     end
-    page = @storage.read("http://example.com", key: "example.com")
+    page = @storage.read(url: "http://example.com", key: "example.com")
     expected_page = {
       url: "http://example.com",
       key: "example.com",
@@ -53,7 +53,7 @@ class DaimonSkycrawlers::Storage::RDBTest < Test::Unit::TestCase
     assert_nothing_raised do
       @storage.save(data)
     end
-    page = @storage.read("http://example.com")
+    page = @storage.read(url: "http://example.com")
     expected_page = {
       url: "http://example.com",
       key: "http://example.com",


### PR DESCRIPTION
`storage.read(url, message)` ->
`storage.read(message)`

Because `message` includes `:url` key that represents URL.